### PR TITLE
Dockerfile: Remove VOLUME instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ COPY --from=builder ${FROM_DIRECTORY}/consoles/                             /usr
 
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 RUN mkdir -p /prometheus && \
-    chown -R nobody:nobody etc/prometheus /prometheus
+    chgrp -R 0 /etc/prometheus /prometheus && \
+    chmod -R g=u /etc/prometheus /prometheus
 
 USER       nobody
 EXPOSE     9090
-VOLUME     [ "/prometheus" ]
 WORKDIR    /etc/prometheus
 ENTRYPOINT [ "/bin/prometheus" ]

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -19,11 +19,11 @@ COPY --from=builder ${FROM_DIRECTORY}/consoles/                             /usr
 
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 RUN mkdir -p /prometheus && \
-    chown -R nobody:nobody etc/prometheus /prometheus
+    chgrp -R 0 /etc/prometheus /prometheus && \
+    chmod -R g=u /etc/prometheus /prometheus
 
 USER       nobody
 EXPOSE     9090
-VOLUME     [ "/prometheus" ]
 WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus" ]
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -10,11 +10,11 @@ RUN yum install -y prometheus && \
     yum clean all
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 RUN mkdir -p /prometheus && \
-    chown -R nobody:nobody etc/prometheus /prometheus
+    chgrp -R 0 /etc/prometheus /prometheus && \
+    chmod -R g=u /etc/prometheus /prometheus
 
 USER       nobody
 EXPOSE     9090
-VOLUME     [ "/prometheus" ]
 WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus" ]
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \


### PR DESCRIPTION
Following up on https://github.com/prometheus/prometheus/pull/5050.

> This instruction is usually useless e.g. when using Docker's novolume-plugin and in cloud environments.
> 
> In cloud environments volumes must be mounted and there's no point in keeping Prometheus data temporary volume dir only during life-time of a container. In local environments writable layers storage is good enough for testing.
> 
> Another downside of using VOLUME instruction is it hard to undone it in child images and one would need to re-write the Dockerfile.
> 
> If there are no BC breaks after this change I think it'll make life easier for many people.