### PR TITLE
Install promu package for OCP multistage builds

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,7 +1,8 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/prometheus/prometheus
 COPY . .
-RUN make build
+ARG BUILD_PROMU=false
+RUN yum install -y prometheus-promu && make build && yum clean all
 
 FROM  registry.svc.ci.openshift.org/ocp/4.0:base
 LABEL io.k8s.display-name="OpenShift Prometheus" \


### PR DESCRIPTION
We need `promu` to build Prometheus but we should use the promu package instead of the upstream version because 1) we're not allowed to download stuff from the outside and 2) this promu version generates proper binaries for OCP (eg dynamically linked with glibc).

