### PR TITLE
Fix bad date error in 3.11 spec file

### DIFF
--- a/golang-github-prometheus-prometheus.spec
+++ b/golang-github-prometheus-prometheus.spec
@@ -90,7 +90,7 @@ install -D -p -m 0644 consoles/* %{buildroot}%{_datadir}/prometheus/consoles
 %{_datadir}/prometheus/consoles
 
 %changelog
-* Jan Thu 31 2019 Simon Pasquier <spasquie@redhat.com> - 2.3.2-4
+* Thu Jan 31 2019 Simon Pasquier <spasquie@redhat.com> - 2.3.2-4
 - Remove highlight code in the UI.
 
 * Thu Sep 27 2018 Simon Pasquier <spasquie@redhat.com> - 2.3.2-3


### PR DESCRIPTION
@simonpasquier This bad date formatting is currently blocking the OCP 3.11 build because tito refuses to continue with a bad date format in the changelog. All I've done here is fix it to match the format from a similar change you did in the master branch.
Please merge ASAP so we can get the build running again :)
Thanks!