### PR TITLE
unify Dockerfile naming and bring in upstream Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,23 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
-WORKDIR /go/src/github.com/prometheus/prometheus
-COPY . .
-RUN make build
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-LABEL io.k8s.display-name="OpenShift Prometheus" \
-      io.k8s.description="The Prometheus monitoring system and time series database." \
-      io.openshift.tags="prometheus,monitoring" \
-      maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>" \
-      version="v2.10.0"
-
-ARG FROM_DIRECTORY=/go/src/github.com/prometheus/prometheus
-COPY --from=builder ${FROM_DIRECTORY}/prometheus                            /bin/prometheus
-COPY --from=builder ${FROM_DIRECTORY}/promtool                              /bin/promtool
-COPY --from=builder ${FROM_DIRECTORY}/documentation/examples/prometheus.yml /etc/prometheus/prometheus.yml
-COPY --from=builder ${FROM_DIRECTORY}/console_libraries/                    /usr/share/prometheus/console_libraries/
-COPY --from=builder ${FROM_DIRECTORY}/consoles/                             /usr/share/prometheus/consoles/
+ARG ARCH="amd64"
+ARG OS="linux"
+COPY .build/${OS}-${ARCH}/prometheus        /bin/prometheus
+COPY .build/${OS}-${ARCH}/promtool          /bin/promtool
+COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
+COPY console_libraries/                     /usr/share/prometheus/console_libraries/
+COPY consoles/                              /usr/share/prometheus/consoles/
 
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/
 RUN mkdir -p /prometheus && \
-    chgrp -R 0 /etc/prometheus /prometheus && \
-    chmod -R g=u /etc/prometheus /prometheus
+    chown -R nobody:nogroup etc/prometheus /prometheus
 
 USER       nobody
 EXPOSE     9090
+VOLUME     [ "/prometheus" ]
 WORKDIR    /prometheus
 ENTRYPOINT [ "/bin/prometheus" ]
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,15 +1,14 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 WORKDIR /go/src/github.com/prometheus/prometheus
 COPY . .
-ARG BUILD_PROMU=false
-RUN yum install -y prometheus-promu && make build && yum clean all
+RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make build 
 
-FROM  registry.svc.ci.openshift.org/ocp/4.0:base
+FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 LABEL io.k8s.display-name="OpenShift Prometheus" \
       io.k8s.description="The Prometheus monitoring system and time series database." \
       io.openshift.tags="prometheus,monitoring" \
       maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
-      version="v2.7.2"
+      version="v2.10.0"
 
 ARG FROM_DIRECTORY=/go/src/github.com/prometheus/prometheus
 COPY --from=builder ${FROM_DIRECTORY}/prometheus                            /bin/prometheus


### PR DESCRIPTION
- `mv Dockerfile.rhel Dockerfile.ocp`
- Bring in upstream Dockerfile (just to keep it clean)

CI will fail as it needs openshift/release#4235 first.