### PR TITLE
Remove patches required for Go < 1.12

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -273,8 +273,7 @@ func (sp *scrapePool) stop() {
 		delete(sp.activeTargets, fp)
 	}
 	wg.Wait()
-	// Disabled until Go 1.12 is used.
-	//sp.client.CloseIdleConnections()
+	sp.client.CloseIdleConnections()
 }
 
 // reload the scrape pool with the given scrape configuration. The target state is preserved
@@ -293,8 +292,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 		return errors.Wrap(err, "error creating HTTP client")
 	}
 	sp.config = cfg
-	// Disabled until Go 1.12 is used.
-	//oldClient := sp.client
+	oldClient := sp.client
 	sp.client = client
 
 	var (
@@ -333,8 +331,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 	}
 
 	wg.Wait()
-	// Disabled until Go 1.12 is used.
-	//oldClient.CloseIdleConnections()
+	oldClient.CloseIdleConnections()
 	targetReloadIntervalLength.WithLabelValues(interval.String()).Observe(
 		time.Since(start).Seconds(),
 	)

--- a/tsdb/goversion/goversion.go
+++ b/tsdb/goversion/goversion.go
@@ -11,9 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Allow Go 1.11 until Go 1.12 is used.
-// Go 1.12 is only required to support darwin platforms properly.
-// +build go1.11
+// +build go1.12
 
 // Package goversion enforces the go version suported by the tsdb module.
 package goversion


### PR DESCRIPTION
Go 1.12 is available for OpenShift 4.3 and onwards.