### PR TITLE
web/ui: disable React-based UI

### DIFF
--- a/web/ui/ui.go
+++ b/web/ui/ui.go
@@ -47,6 +47,12 @@ var Assets = func() http.FileSystem {
 	static := filter.Keep(
 		http.Dir(path.Join(assetsPrefix, "static")),
 		func(path string, fi os.FileInfo) bool {
+			// Disable the experimental React-based UI in OCP builds.
+			// TODO: to be removed when the legacy UI is replaced by the React UI.
+			if strings.HasPrefix(path, "/react") {
+				return false
+			}
+			// End TODO
 			return fi.IsDir() ||
 				(!strings.HasSuffix(path, "map.js") &&
 					!strings.HasSuffix(path, "/bootstrap.js") &&


### PR DESCRIPTION
The link to the new React-based UI was already removed from the OCP
version of Prometheus to avoid getting support requests for a feature
that is still experimental upstream. However it was possible to access
this UI by accessing the /graph/new URL manually.

This change removes completely the embedded React assets from the
generated binary. Someone trying to access /graph/new URL will
encounter a 404 error.

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->