### PR TITLE
Updating golang-github-prometheus-prometheus builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/prometheus/prometheus
 COPY . .
 # NOTE(spasquie): the 'build' target regenerates the ReactJS code and the Go
@@ -9,7 +9,7 @@ COPY . .
 # should be committed to the repository.
 RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make common-build
 
-FROM  registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 LABEL io.k8s.display-name="OpenShift Prometheus" \
       io.k8s.description="The Prometheus monitoring system and time series database." \
       io.openshift.tags="prometheus,monitoring" \


### PR DESCRIPTION
Updating golang-github-prometheus-prometheus builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/golang-github-prometheus-prometheus.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
