### PR TITLE
Bug 1925061: disable using MADV_FREE to release unused memory

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -28,6 +28,8 @@ RUN mkdir -p /prometheus && \
     chgrp -R 0 /etc/prometheus /prometheus && \
     chmod -R g=u /etc/prometheus /prometheus
 
+ENV GODEBUG=x509ignoreCN=0,madvdontneed=1
+
 USER       nobody
 EXPOSE     9090
 WORKDIR    /prometheus


### PR DESCRIPTION
As in title. This is for testing a possible solution to OOMKilling prometheus during upgrades.

/cc @s-urbaniak @sdodson @bparees 