### PR TITLE
head_chunks: include filesize into mmapedChunkFile to avoid file read

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -409,14 +409,24 @@ type ByteSlice interface {
 	Range(start, end int) []byte
 }
 
-type realByteSlice []byte
+type realByteSlice struct {
+	b []byte
+	s int
+}
+
+func newRealByteSlice(b []byte, size int) ByteSlice {
+	return realByteSlice{
+		b: b,
+		s: size,
+	}
+}
 
 func (b realByteSlice) Len() int {
-	return len(b)
+	return b.s
 }
 
 func (b realByteSlice) Range(start, end int) []byte {
-	return b[start:end]
+	return b.b[start:end]
 }
 
 // Reader implements a ChunkReader for a serialized byte stream
@@ -474,7 +484,7 @@ func NewDirReader(dir string, pool chunkenc.Pool) (*Reader, error) {
 			).Err()
 		}
 		cs = append(cs, f)
-		bs = append(bs, realByteSlice(f.Bytes()))
+		bs = append(bs, newRealByteSlice(f.Bytes(), f.Size()))
 	}
 
 	reader, err := newReader(bs, cs, pool)

--- a/tsdb/chunks/chunks_test.go
+++ b/tsdb/chunks/chunks_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestReaderWithInvalidBuffer(t *testing.T) {
-	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+	b := newRealByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81}, 6)
 	r := &Reader{bs: []ByteSlice{b}}
 
 	_, err := r.Chunk(0)

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -188,7 +188,7 @@ func (cdm *ChunkDiskMapper) openMMapFiles() (returnErr error) {
 			return errors.Wrapf(err, "mmap files, file: %s", fn)
 		}
 		cdm.closers[seq] = f
-		cdm.mmappedChunkFiles[seq] = &mmappedChunkFile{byteSlice: realByteSlice(f.Bytes())}
+		cdm.mmappedChunkFiles[seq] = &mmappedChunkFile{byteSlice: newRealByteSlice(f.Bytes(), f.Size())}
 		chkFileIndices = append(chkFileIndices, seq)
 	}
 
@@ -401,7 +401,7 @@ func (cdm *ChunkDiskMapper) cut() (returnErr error) {
 	}
 
 	cdm.closers[cdm.curFileSequence] = mmapFile
-	cdm.mmappedChunkFiles[cdm.curFileSequence] = &mmappedChunkFile{byteSlice: realByteSlice(mmapFile.Bytes())}
+	cdm.mmappedChunkFiles[cdm.curFileSequence] = &mmappedChunkFile{byteSlice: newRealByteSlice(mmapFile.Bytes(), mmapFile.Size())}
 	cdm.readPathMtx.Unlock()
 
 	cdm.curFileMaxt = 0

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -22,6 +22,7 @@ import (
 type MmapFile struct {
 	f *os.File
 	b []byte
+	s int
 }
 
 func OpenMmapFile(path string) (*MmapFile, error) {
@@ -51,7 +52,7 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 		return nil, errors.Wrapf(err, "mmap, size %d", size)
 	}
 
-	return &MmapFile{f: f, b: b}, nil
+	return &MmapFile{f: f, b: b, s: size}, nil
 }
 
 func (f *MmapFile) Close() error {
@@ -70,4 +71,8 @@ func (f *MmapFile) File() *os.File {
 
 func (f *MmapFile) Bytes() []byte {
 	return f.b
+}
+
+func (f *MmapFile) Size() int {
+	return f.s
 }

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -553,7 +553,7 @@ func (w *Writer) finishSymbols() error {
 	}
 
 	// Load in the symbol table efficiently for the rest of the index writing.
-	w.symbols, err = NewSymbols(realByteSlice(w.symbolFile.Bytes()), FormatV2, int(w.toc.Symbols))
+	w.symbols, err = NewSymbols(newRealByteSlice(w.symbolFile.Bytes(), w.symbolFile.Size()), FormatV2, int(w.toc.Symbols))
 	if err != nil {
 		return errors.Wrap(err, "read symbols")
 	}
@@ -572,7 +572,7 @@ func (w *Writer) writeLabelIndices() error {
 	}
 	defer f.Close()
 
-	d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.fPO.pos))
+	d := encoding.NewDecbufRaw(newRealByteSlice(f.Bytes(), f.Size()), int(w.fPO.pos))
 	cnt := w.cntPO
 	current := []byte{}
 	values := []uint32{}
@@ -734,7 +734,7 @@ func (w *Writer) writePostingsOffsetTable() error {
 			f.Close()
 		}
 	}()
-	d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.fPO.pos))
+	d := encoding.NewDecbufRaw(newRealByteSlice(f.Bytes(), f.Size()), int(w.fPO.pos))
 	cnt := w.cntPO
 	for d.Err() == nil && cnt > 0 {
 		w.buf1.Reset()
@@ -813,7 +813,7 @@ func (w *Writer) writePostingsToTmpFiles() error {
 
 	// Write out the special all posting.
 	offsets := []uint32{}
-	d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.toc.LabelIndices))
+	d := encoding.NewDecbufRaw(newRealByteSlice(f.Bytes(), f.Size()), int(w.toc.LabelIndices))
 	d.Skip(int(w.toc.Series))
 	for d.Len() > 0 {
 		d.ConsumePadding()
@@ -859,7 +859,7 @@ func (w *Writer) writePostingsToTmpFiles() error {
 		// Label name -> label value -> positions.
 		postings := map[uint32]map[uint32][]uint32{}
 
-		d := encoding.NewDecbufRaw(realByteSlice(f.Bytes()), int(w.toc.LabelIndices))
+		d := encoding.NewDecbufRaw(newRealByteSlice(f.Bytes(), f.Size()), int(w.toc.LabelIndices))
 		d.Skip(int(w.toc.Series))
 		for d.Len() > 0 {
 			d.ConsumePadding()
@@ -1068,18 +1068,28 @@ type ByteSlice interface {
 	Range(start, end int) []byte
 }
 
-type realByteSlice []byte
+type realByteSlice struct {
+	b []byte
+	s int
+}
+
+func newRealByteSlice(b []byte, size int) ByteSlice {
+	return realByteSlice{
+		b: b,
+		s: size,
+	}
+}
 
 func (b realByteSlice) Len() int {
-	return len(b)
+	return b.s
 }
 
 func (b realByteSlice) Range(start, end int) []byte {
-	return b[start:end]
+	return b.b[start:end]
 }
 
-func (b realByteSlice) Sub(start, end int) ByteSlice {
-	return b[start:end]
+func (b realByteSlice) Sub(start, end int) []byte {
+	return b.b[start:end]
 }
 
 // NewReader returns a new index reader on the given byte slice. It automatically
@@ -1094,7 +1104,7 @@ func NewFileReader(path string) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	r, err := newReader(realByteSlice(f.Bytes()), f)
+	r, err := newReader(newRealByteSlice(f.Bytes(), f.Size()), f)
 	if err != nil {
 		return nil, tsdb_errors.NewMulti(
 			err,

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -486,14 +486,14 @@ func TestPersistence_index_e2e(t *testing.T) {
 }
 
 func TestDecbufUvarintWithInvalidBuffer(t *testing.T) {
-	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+	b := newRealByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81}, 6)
 
 	db := encoding.NewDecbufUvarintAt(b, 0, castagnoliTable)
 	require.Error(t, db.Err())
 }
 
 func TestReaderWithInvalidBuffer(t *testing.T) {
-	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
+	b := newRealByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81}, 6)
 
 	_, err := NewReader(b)
 	require.Error(t, err)
@@ -530,7 +530,7 @@ func TestSymbols(t *testing.T) {
 	checksum := crc32.Checksum(buf.Get()[symbolsStart+4:], castagnoliTable)
 	buf.PutBE32(checksum) // Check sum at the end.
 
-	s, err := NewSymbols(realByteSlice(buf.Get()), FormatV2, symbolsStart)
+	s, err := NewSymbols(newRealByteSlice(buf.Get(), buf.Len()), FormatV2, symbolsStart)
 	require.NoError(t, err)
 
 	// We store only 4 offsets to symbols.


### PR DESCRIPTION
b.byteSlice.Len() reads the entire mmaped file into memory to find out
the file size. Avoid this by passing the size to mmappedChunkFile to use
later to see if the header is valid.

Signed-off-by: Ryan Phillips <rphillips@redhat.com>

