### PR TITLE
Dockerfile.ocp: enable GC trace

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -28,6 +28,7 @@ RUN mkdir -p /prometheus && \
     chgrp -R 0 /etc/prometheus /prometheus && \
     chmod -R g=u /etc/prometheus /prometheus
 
+ENV        GODEBUG=gctrace=1,scavtrace=1
 USER       nobody
 EXPOSE     9090
 WORKDIR    /prometheus


### PR DESCRIPTION
/hold

Enabling GC traces to track memory usage during upgrades.