### PR TITLE
[WIP] call runtime.GC() once TSDB loaded

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -28,6 +28,7 @@ RUN mkdir -p /prometheus && \
     chgrp -R 0 /etc/prometheus /prometheus && \
     chmod -R g=u /etc/prometheus /prometheus
 
+ENV        GODEBUG=gctrace=1,scavtrace=1
 USER       nobody
 EXPOSE     9090
 WORKDIR    /prometheus

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -732,6 +732,7 @@ func main() {
 					level.Info(logger).Log("fs_type", fsType)
 				}
 
+				runtime.GC()
 				level.Info(logger).Log("msg", "TSDB started")
 				level.Debug(logger).Log("msg", "TSDB options",
 					"MinBlockDuration", cfg.tsdb.MinBlockDuration,


### PR DESCRIPTION
Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->