### PR TITLE
Bug 2056802: scrape: Fix label_limits cache usage

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1769,9 +1769,6 @@ func zeroConfig(c *config.ScrapeConfig) *config.ScrapeConfig {
 	z.ScrapeInterval = 0
 	z.ScrapeTimeout = 0
 	z.SampleLimit = 0
-	z.LabelLimit = 0
-	z.LabelNameLengthLimit = 0
-	z.LabelValueLengthLimit = 0
 	z.HTTPClientConfig = config_util.HTTPClientConfig{}
 	return &z
 }

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2518,6 +2518,14 @@ func TestReuseScrapeCache(t *testing.T) {
 					Name:  "labelNew",
 					Value: "nameNew",
 				},
+				labels.Label{
+					Name:  "labelNew1",
+					Value: "nameNew1",
+				},
+				labels.Label{
+					Name:  "labelNew2",
+					Value: "nameNew2",
+				},
 			},
 		}
 		proxyURL, _ = url.Parse("http://localhost:2128")
@@ -2592,6 +2600,49 @@ func TestReuseScrapeCache(t *testing.T) {
 				ScrapeInterval:  model.Duration(5 * time.Second),
 				ScrapeTimeout:   model.Duration(15 * time.Second),
 				MetricsPath:     "/metrics2",
+			},
+		},
+		{
+			keep: false,
+			newConfig: &config.ScrapeConfig{
+				JobName:        "Prometheus",
+				ScrapeInterval: model.Duration(5 * time.Second),
+				ScrapeTimeout:  model.Duration(15 * time.Second),
+				MetricsPath:    "/metrics",
+				LabelLimit:     1,
+			},
+		},
+		{
+			keep: false,
+			newConfig: &config.ScrapeConfig{
+				JobName:        "Prometheus",
+				ScrapeInterval: model.Duration(5 * time.Second),
+				ScrapeTimeout:  model.Duration(15 * time.Second),
+				MetricsPath:    "/metrics",
+				LabelLimit:     15,
+			},
+		},
+		{
+			keep: false,
+			newConfig: &config.ScrapeConfig{
+				JobName:              "Prometheus",
+				ScrapeInterval:       model.Duration(5 * time.Second),
+				ScrapeTimeout:        model.Duration(15 * time.Second),
+				MetricsPath:          "/metrics",
+				LabelLimit:           15,
+				LabelNameLengthLimit: 5,
+			},
+		},
+		{
+			keep: false,
+			newConfig: &config.ScrapeConfig{
+				JobName:               "Prometheus",
+				ScrapeInterval:        model.Duration(5 * time.Second),
+				ScrapeTimeout:         model.Duration(15 * time.Second),
+				MetricsPath:           "/metrics",
+				LabelLimit:            15,
+				LabelNameLengthLimit:  5,
+				LabelValueLengthLimit: 7,
 			},
 		},
 	}


### PR DESCRIPTION

We had to put https://github.com/openshift/cluster-monitoring-operator/pull/1350 on hold till we fix label_limits issue. This is fixed upstream and this pr is cherry pick from commit edfe657b54057e427469a2151153d305270662a4

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
