### PR TITLE
web/ui/.gitignore: unignore generated assets for downstream build

### DIFF
--- a/web/ui/.gitignore
+++ b/web/ui/.gitignore
@@ -1,2 +1,5 @@
-*.gz
-embed.go
+# NOTE(jan--f): unlike upstream, we want the assets to be committed in the repository because build environments don't have access to Yarn and external package repositories.
+# This means that every time we update to a new Prometheus version, 'make assets-compress' should be run and the resulting file committed to the repository.
+# Simply adding the files is not sufficient since the ART workflow is based on rebases and looses ignored but added files.
+# *.gz
+# embed.go


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
