### PR TITLE
Revert unwanted downstream patch

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/units"
-	kitloglevel "github.com/go-kit/kit/log/level"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
@@ -528,27 +527,11 @@ func main() {
 	noStepSubqueryInterval := &safePromQLNoStepSubqueryInterval{}
 	noStepSubqueryInterval.Set(config.DefaultGlobalConfig.EvaluationInterval)
 
-	// FIXME: Temporary workaround until a proper solution is found. go-kit's
-	// level packages use private types to determine the level so we have to use
-	// the same level package as the underlying library.
-	var lvl kitloglevel.Option
-	switch cfg.promlogConfig.Level.String() {
-	case "debug":
-		lvl = kitloglevel.AllowDebug()
-	case "info":
-		lvl = kitloglevel.AllowInfo()
-	case "warn":
-		lvl = kitloglevel.AllowWarn()
-	case "error":
-		lvl = kitloglevel.AllowError()
-	}
-	kloglogger := kitloglevel.NewFilter(logger, lvl)
-
 	// Above level 6, the k8s client would log bearer tokens in clear-text.
 	klog.ClampLevel(6)
-	klog.SetLogger(log.With(kloglogger, "component", "k8s_client_runtime"))
+	klog.SetLogger(log.With(logger, "component", "k8s_client_runtime"))
 	klogv2.ClampLevel(6)
-	klogv2.SetLogger(log.With(kloglogger, "component", "k8s_client_runtime"))
+	klogv2.SetLogger(log.With(logger, "component", "k8s_client_runtime"))
 
 	modeAppName := "Prometheus Server"
 	mode := "server"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/envoyproxy/go-control-plane v0.10.3
 	github.com/envoyproxy/protoc-gen-validate v0.6.8
 	github.com/fsnotify/fsnotify v1.5.4
-	github.com/go-kit/kit v0.10.0
 	github.com/go-kit/log v0.2.1
 	github.com/go-logfmt/logfmt v0.5.1
 	github.com/go-openapi/strfmt v0.21.3
@@ -107,6 +106,7 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.2 // indirect


### PR DESCRIPTION
This repository carries a hot-fix from v2.28.1 upstream [1] that was later reverted [2]. For some reason, our sync workflow failed to apply the upstream revert and we're left with a patch in our downstream that isn't necessary.

[1] https://github.com/prometheus/prometheus/pull/9021 [2] https://github.com/prometheus/prometheus/pull/9121

Signed-off-by: Simon Pasquier <spasquie@redhat.com>

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
