### PR TITLE
OCPBUGS-35483: cherry-pick upstream fix to make PrometheusRemoteWriteBehind fire when remote endpoint is never reached.

### DIFF
--- a/storage/remote/max_timestamp.go
+++ b/storage/remote/max_timestamp.go
@@ -39,9 +39,3 @@ func (m *maxTimestamp) Get() float64 {
 	defer m.mtx.Unlock()
 	return m.value
 }
-
-func (m *maxTimestamp) Collect(c chan<- prometheus.Metric) {
-	if m.Get() > 0 {
-		m.Gauge.Collect(c)
-	}
-}

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -229,7 +229,7 @@ func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManager
 			Namespace:   namespace,
 			Subsystem:   subsystem,
 			Name:        "queue_highest_sent_timestamp_seconds",
-			Help:        "Timestamp from a WAL sample, the highest timestamp successfully sent by this queue, in seconds since epoch.",
+			Help:        "Timestamp from a WAL sample, the highest timestamp successfully sent by this queue, in seconds since epoch. Initialized to 0 when no data has been sent yet.",
 			ConstLabels: constLabels,
 		}),
 	}

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -55,7 +55,7 @@ func newHighestTimestampMetric() *maxTimestamp {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "highest_timestamp_in_seconds",
-			Help:      "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch.",
+			Help:      "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch. Initialized to 0 when no data has been received yet",
 		}),
 	}
 }

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -97,7 +97,7 @@ func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, dir string, f
 				Namespace: namespace,
 				Subsystem: subsystem,
 				Name:      "highest_timestamp_in_seconds",
-				Help:      "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch.",
+				Help:      "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch. Initialized to 0 when no data has been received yet.",
 			}),
 		},
 	}


### PR DESCRIPTION
chore(storage/remote): collect maxTimestamp when value is 0 as well.

This change enables the PrometheusRemoteWriteBehind alert’s expression to be evaluated even when the remote endpoint has never been reached. As a result, PrometheusRemoteWriteBehind will fire to easily detect configuration mistakes (such as incorrect endpoint URLs) or unrecoverable connectivity issues.

See https://github.com/prometheus/prometheus/issues/14350 for details.

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
