### PR TITLE
OCPBUGS-48273: fix(main.go): avoid closing the query engine until it is guaranteed to no longer be in use

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1000,18 +1000,12 @@ func main() {
 	listeners, err := webHandler.Listeners()
 	if err != nil {
 		level.Error(logger).Log("msg", "Unable to start web listeners", "err", err)
-		if err := queryEngine.Close(); err != nil {
-			level.Warn(logger).Log("msg", "Closing query engine failed", "err", err)
-		}
 		os.Exit(1)
 	}
 
 	err = toolkit_web.Validate(*webConfig)
 	if err != nil {
 		level.Error(logger).Log("msg", "Unable to validate web configuration file", "err", err)
-		if err := queryEngine.Close(); err != nil {
-			level.Warn(logger).Log("msg", "Closing query engine failed", "err", err)
-		}
 		os.Exit(1)
 	}
 
@@ -1032,9 +1026,6 @@ func main() {
 					level.Warn(logger).Log("msg", "Received termination request via web service, exiting gracefully...")
 				case <-cancel:
 					reloadReady.Close()
-				}
-				if err := queryEngine.Close(); err != nil {
-					level.Warn(logger).Log("msg", "Closing query engine failed", "err", err)
 				}
 				return nil
 			},

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -434,6 +434,8 @@ func NewEngine(opts EngineOpts) *Engine {
 }
 
 // Close closes ng.
+// Callers must ensure the engine is really no longer in use before calling this to avoid
+// issues failures like in https://github.com/prometheus/prometheus/issues/15232
 func (ng *Engine) Close() error {
 	if ng == nil {
 		return nil


### PR DESCRIPTION
cherry-pick of https://github.com/prometheus/prometheus/pull/15723

---

partially reverts https://github.com/prometheus/prometheus/pull/14064

fixes https://github.com/prometheus/prometheus/issues/15232

supersedes https://github.com/prometheus/prometheus/pull/15533

reusing Engine.Close() outside of tests will require more consideration.

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
