### PR TITLE
OCPBUGS-39089: Clarify prometheus pod NFS warning message

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1250,7 +1250,7 @@ func main() {
 
 				switch fsType := prom_runtime.Statfs(localStoragePath); fsType {
 				case "NFS_SUPER_MAGIC":
-					logger.Warn("This filesystem is not supported and may lead to data corruption and data loss. Please carefully read https://prometheus.io/docs/prometheus/latest/storage/ to learn more about supported filesystems.", "fs_type", fsType)
+					logger.Warn("This filesystem is generally not recommended for Prometheus and may lead to data corruption and data loss. Some NFS implementations may work if they are POSIX-compliant. Please consult the documentation and carefully consider your NFS implementation: https://prometheus.io/docs/prometheus/latest/storage/", "fs_type", fsType)
 				default:
 					logger.Info("filesystem information", "fs_type", fsType)
 				}
@@ -1306,7 +1306,7 @@ func main() {
 
 				switch fsType := prom_runtime.Statfs(localStoragePath); fsType {
 				case "NFS_SUPER_MAGIC":
-					logger.Warn(fsType, "msg", "This filesystem is not supported and may lead to data corruption and data loss. Please carefully read https://prometheus.io/docs/prometheus/latest/storage/ to learn more about supported filesystems.")
+					logger.Warn(fsType, "msg", "This filesystem is generally not recommended for Prometheus and may lead to data corruption and data loss. Some NFS implementations may work if they are POSIX-compliant. Please consult the documentation and carefully consider your NFS implementation: https://prometheus.io/docs/prometheus/latest/storage/")
 				default:
 					logger.Info(fsType)
 				}


### PR DESCRIPTION
This commit mofifies the warning log for NFS filesystems to clarify that while
NFS is generally not recommended for Prometheus, certain POSIX-compliant NFS
implementations may be usable.

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
