### PR TITLE
OCPBUGS-62429: chore(scrape): default to legacy validation/escaping scheme until utf-8 is fully supported by prometheus-operator

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -773,4 +774,47 @@ func prometheusCommandWithLogging(t *testing.T, configFilePath string, port int,
 		wg.Wait()
 	})
 	return prom
+}
+
+// TestScrapeHeaderDoesNotContainAllowUTF8 ensures that Prometheus doesn't ask
+// for utf8 when scraping targets.
+func TestUTF8DisabledOnScrape(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "prometheus.yml")
+
+	headerChecked := make(chan bool)
+	targetServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		acceptHeader := r.Header.Get("Accept")
+		require.NotContains(t, acceptHeader, "utf-8")
+		require.NotContains(t, acceptHeader, "utf8")
+		headerChecked <- true
+	}))
+	t.Cleanup(targetServer.Close)
+	targetURL, err := url.Parse(targetServer.URL)
+	require.NoError(t, err)
+
+	config := fmt.Sprintf(`
+scrape_configs:
+  - job_name: 'target'
+    scrape_interval: 100ms
+    static_configs:
+      - targets: ['%s']
+`, targetURL.Host)
+	require.NoError(t, os.WriteFile(configFile, []byte(config), 0o777))
+
+	prom := prometheusCommandWithLogging(
+		t,
+		configFile,
+		testutil.RandomUnprivilegedPort(t),
+		fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
+	)
+	require.NoError(t, prom.Start())
+
+	select {
+	case <-headerChecked:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Timeout waiting for target to be scraped")
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -849,6 +849,10 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 		c.MetricNameValidationScheme = globalConfig.MetricNameValidationScheme
 	}
 
+	// Default to legacy validation scheme.
+	// TODO: remove once utf-8 is fully supported.
+	c.MetricNameValidationScheme = LegacyValidationConfig
+
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -319,6 +319,7 @@ var expectedConf = &Config{
 					Separator:    relabel.DefaultRelabelConfig.Separator,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-x",
@@ -417,6 +418,7 @@ var expectedConf = &Config{
 					Action:       relabel.Drop,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-y",
@@ -473,6 +475,7 @@ var expectedConf = &Config{
 					Action:       relabel.Replace,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-z",
@@ -507,6 +510,7 @@ var expectedConf = &Config{
 				FollowRedirects: true,
 				EnableHTTP2:     true,
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-kubernetes",
@@ -547,6 +551,7 @@ var expectedConf = &Config{
 					NamespaceDiscovery: kubernetes.NamespaceDiscovery{},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-kubernetes-namespaces",
@@ -587,6 +592,7 @@ var expectedConf = &Config{
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-kuma",
@@ -617,6 +623,7 @@ var expectedConf = &Config{
 					FetchTimeout:     model.Duration(2 * time.Minute),
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-marathon",
@@ -655,6 +662,7 @@ var expectedConf = &Config{
 					},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-nomad",
@@ -690,6 +698,7 @@ var expectedConf = &Config{
 					},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-ec2",
@@ -732,6 +741,7 @@ var expectedConf = &Config{
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-lightsail",
@@ -764,6 +774,7 @@ var expectedConf = &Config{
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-azure",
@@ -799,6 +810,7 @@ var expectedConf = &Config{
 					HTTPClientConfig:     config.DefaultHTTPClientConfig,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-nerve",
@@ -827,6 +839,7 @@ var expectedConf = &Config{
 					Timeout: model.Duration(10 * time.Second),
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "0123service-xxx",
@@ -858,6 +871,7 @@ var expectedConf = &Config{
 					},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "badfederation",
@@ -889,6 +903,7 @@ var expectedConf = &Config{
 					},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "測試",
@@ -920,6 +935,7 @@ var expectedConf = &Config{
 					},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "httpsd",
@@ -948,6 +964,7 @@ var expectedConf = &Config{
 					RefreshInterval:  model.Duration(60 * time.Second),
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-triton",
@@ -984,6 +1001,7 @@ var expectedConf = &Config{
 					},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "digitalocean-droplets",
@@ -1019,6 +1037,7 @@ var expectedConf = &Config{
 					RefreshInterval: model.Duration(60 * time.Second),
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "docker",
@@ -1051,6 +1070,7 @@ var expectedConf = &Config{
 					MatchFirstNetwork:  true,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "dockerswarm",
@@ -1082,6 +1102,7 @@ var expectedConf = &Config{
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-openstack",
@@ -1117,6 +1138,7 @@ var expectedConf = &Config{
 					},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-puppetdb",
@@ -1156,6 +1178,7 @@ var expectedConf = &Config{
 					},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName:               "hetzner",
@@ -1212,6 +1235,7 @@ var expectedConf = &Config{
 					Role:            "robot",
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "service-eureka",
@@ -1240,6 +1264,7 @@ var expectedConf = &Config{
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "ovhcloud",
@@ -1279,6 +1304,7 @@ var expectedConf = &Config{
 					Service:           "dedicated_server",
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "scaleway",
@@ -1324,6 +1350,7 @@ var expectedConf = &Config{
 					Zone:             "fr-par-1",
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "linode-instances",
@@ -1360,6 +1387,7 @@ var expectedConf = &Config{
 					RefreshInterval: model.Duration(60 * time.Second),
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "uyuni",
@@ -1391,6 +1419,7 @@ var expectedConf = &Config{
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName:               "ionos",
@@ -1423,6 +1452,7 @@ var expectedConf = &Config{
 					RefreshInterval: model.Duration(60 * time.Second),
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 		{
 			JobName: "vultr",
@@ -1458,6 +1488,7 @@ var expectedConf = &Config{
 					RefreshInterval: model.Duration(60 * time.Second),
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		},
 	},
 	AlertingConfig: AlertingConfig{
@@ -2299,6 +2330,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 					},
 				},
 			},
+			MetricNameValidationScheme: LegacyValidationConfig,
 		}
 	}
 
@@ -2363,6 +2395,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 							},
 						},
 					},
+					MetricNameValidationScheme: LegacyValidationConfig,
 				},
 				{
 					JobName: "node",
@@ -2400,6 +2433,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 							RefreshInterval: model.Duration(60 * time.Second),
 						},
 					},
+					MetricNameValidationScheme: LegacyValidationConfig,
 				},
 			},
 		},
@@ -2466,7 +2500,7 @@ func TestScrapeConfigNameValidationSettings(t *testing.T) {
 		{
 			name:         "blank config implies default",
 			inputFile:    "scrape_config_default_validation_mode",
-			expectScheme: "",
+			expectScheme: "legacy",
 		},
 		{
 			name:         "global setting implies local settings",
@@ -2481,7 +2515,7 @@ func TestScrapeConfigNameValidationSettings(t *testing.T) {
 		{
 			name:         "local setting overrides global setting",
 			inputFile:    "scrape_config_local_global_validation_mode",
-			expectScheme: "utf8",
+			expectScheme: "legacy",
 		},
 	}
 


### PR DESCRIPTION
backport of https://github.com/openshift/prometheus/pull/273 to 4.19


<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
