### PR TITLE
[openshift-4.22] OCPBUGS-88666: remote: validate snappy decoded length before allocation in read endpoint 

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -67,6 +67,14 @@ func DecodeReadRequest(r *http.Request) (*prompb.ReadRequest, error) {
 		return nil, err
 	}
 
+	decodedLen, err := snappy.DecodedLen(compressed)
+	if err != nil {
+		return nil, err
+	}
+	if decodedLen > decodeReadLimit {
+		return nil, fmt.Errorf("snappy: decoded length %d exceeds limit %d", decodedLen, decodeReadLimit)
+	}
+
 	reqBuf, err := snappy.Decode(nil, compressed)
 	if err != nil {
 		return nil, err

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"sync"
 	"testing"
 
@@ -727,6 +728,17 @@ func TestMergeLabels(t *testing.T) {
 	} {
 		require.Equal(t, tc.expected, MergeLabels(tc.primary, tc.secondary))
 	}
+}
+
+func TestDecodeReadRequestTooLarge(t *testing.T) {
+	// 5-byte snappy stream whose header claims 256 MiB decoded length,
+	// well above decodeReadLimit (32 MiB).
+	bomb := []byte{0x80, 0x80, 0x80, 0x80, 0x01}
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(bomb))
+	require.NoError(t, err)
+
+	_, err = DecodeReadRequest(req)
+	require.ErrorContains(t, err, "exceeds limit")
 }
 
 func TestDecodeWriteRequest(t *testing.T) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-88666
CVE-2026-42154 openshift4/ose-prometheus-rhel9: Prometheus: Denial of Service via uncontrolled memory allocation in remote read endpoint [openshift-4.22]

Already fixed - cherry picking commit 3273935