### PR TITLE
OCPBUGS-92191: fix(tsdb): temporarily ignore Direct IO enablement errors on unsupported filesystems

### DIFF
--- a/tsdb/fileutil/direct_io_writer.go
+++ b/tsdb/fileutil/direct_io_writer.go
@@ -328,6 +328,8 @@ func fileStatusFlags(fd uintptr) (int, error) {
 	return flag, err
 }
 
+var fcntlInt = unix.FcntlInt
+
 // enableDirectIO enables Direct IO on the file if needed.
 func enableDirectIO(fd uintptr) error {
 	flag, err := fileStatusFlags(fd)
@@ -339,9 +341,13 @@ func enableDirectIO(fd uintptr) error {
 		return nil
 	}
 
-	_, err = unix.FcntlInt(fd, unix.F_SETFL, flag|unix.O_DIRECT)
+	_, err = fcntlInt(fd, unix.F_SETFL, flag|unix.O_DIRECT)
 	if err != nil {
-		return fmt.Errorf("cannot enable Direct IO: %w", err)
+		// Enabling O_DIRECT via fcntl(F_SETFL) on an already-opened file is not supported on some
+		// filesystems (e.g. GPFS: https://www.ibm.com/docs/en/storage-scale/6.0.1?topic=applications-considerations-use-direct-io-o-direct).
+		// In that case we currently silently fall back to buffered IO while still honouring alignment requirements, which is harmless.
+		// TODO: make it possible to open the file with O_DIRECT from the start instead of retrofitting it via fcntl.
+		return nil
 	}
 	return nil
 }

--- a/tsdb/fileutil/direct_io_writer_test.go
+++ b/tsdb/fileutil/direct_io_writer_test.go
@@ -16,12 +16,14 @@
 package fileutil
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func directIORqmtsForTest(tb testing.TB) *directIORqmts {
@@ -39,6 +41,44 @@ func TestDirectIOFile(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, enableDirectIO(f.Fd()))
+}
+
+func TestEnableDirectIO(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	f, err := os.OpenFile(path.Join(tmpDir, "test"), os.O_CREATE|os.O_WRONLY, 0o666)
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "success",
+		},
+		{
+			name: "EINVAL is silently ignored",
+			err:  unix.EINVAL,
+		},
+		{
+			name: "other errors are silently ignored",
+			err:  fmt.Errorf("unexpected error"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := fcntlInt
+			t.Cleanup(func() { fcntlInt = original })
+
+			fcntlInt = func(fd uintptr, cmd, arg int) (int, error) {
+				return 0, tc.err
+			}
+
+			require.NoError(t, enableDirectIO(f.Fd()))
+		})
+	}
 }
 
 func TestAlignedBlockEarlyPanic(t *testing.T) {


### PR DESCRIPTION
Some filesystems (e.g. GPFS) do not support enabling O_DIRECT via fcntl(F_SETFL) on an already-opened file. Temporarily silently fall back to buffered IO in that case; writing with aligned buffers on buffered IO is not a problem. This is preferable to having to identify setups where the feature flag must be disabled. Changes upstream will allow opening files with O_DIRECT from the start instead of retrofitting it via fcntl.

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
