### PR TITLE
NO-JIRA: chore: revert narrow selectors detection for le/quantile labels

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -650,9 +650,6 @@ func main() {
 
 	logger := promslog.New(&cfg.promslogConfig)
 	slog.SetDefault(logger)
-	// Hacky but temporary
-	parser.Logger = logger.With("component", "parser")
-	relabel.Logger = logger.With("component", "relabel")
 
 	notifs := notifications.NewNotifications(cfg.maxNotificationsSubscribers, prometheus.DefaultRegisterer)
 	cfg.web.NotificationsSub = notifs.Sub

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -24,14 +24,11 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/common/promslog"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
 
 var (
-	Logger = promslog.NewNopLogger()
-
 	// relabelTargetLegacy allows targeting labels with legacy Prometheus character set, plus ${<var>} variables for dynamic characters from source the metrics.
 	relabelTargetLegacy = regexp.MustCompile(`^(?:(?:[a-zA-Z_]|\$(?:\{\w+\}|\w+))+\w*)+$`)
 

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -776,10 +776,6 @@ func generateNativeHistogramCustomBucketsSeries(app storage.Appender, numSeries 
 
 func BenchmarkParser(b *testing.B) {
 	cases := []string{
-		`foo_bucket{a="b",c="d",le=~"1.0|2.0|3.0|4"}`,
-		`bar_bucket{a="b",c="d",le="1.0"}`,
-		`foo{a="b",c="d",quantile="0"}`,
-		`bar{a="b",c="d",quantile="0.99"}`,
 		"a",
 		"metric",
 		"1",

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -24,9 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/common/promslog"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -35,92 +33,6 @@ import (
 	"github.com/prometheus/prometheus/util/features"
 	"github.com/prometheus/prometheus/util/strutil"
 )
-
-var (
-	Logger          = promslog.NewNopLogger()
-	NarrowSelectors = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "prometheus_narrow_selectors_count",
-			Help: "Number of selectors that may unintentionally only match integers on 'quantile' and 'le' labels",
-		},
-		[]string{"component"},
-	)
-)
-
-func init() {
-	prometheus.MustRegister(NarrowSelectors)
-}
-
-// isInteger is a light strconv.Atoi that avoids allocations due to Atoi's returned error and doesn't
-// consider as integers invalid, big, or underscored integers.
-func isInteger(s string) (int, bool) {
-	sLen := len(s)
-	if strconv.IntSize == 32 && (0 < sLen && sLen < 10) ||
-		strconv.IntSize == 64 && (0 < sLen && sLen < 19) {
-		// Fast path for small integers that fit int type.
-		s0 := s
-		if s[0] == '-' || s[0] == '+' {
-			s = s[1:]
-			if len(s) < 1 {
-				return 0, false
-			}
-		}
-
-		n := 0
-		for _, ch := range []byte(s) {
-			ch -= '0'
-			if ch > 9 {
-				return 0, false
-			}
-			n = n*10 + int(ch)
-		}
-		if s0[0] == '-' {
-			n = -n
-		}
-		return n, true
-	}
-
-	// Slow path for invalid, big, or underscored integers.
-	i64, err := strconv.ParseInt(s, 10, 0)
-	return int(i64), err == nil
-}
-
-// checkLabelMatchers helps to detect unintentional misuses of matchers on "quantile" and "le" labels after normalization during scraping
-// introduced in Prometheus3. For more details, see https://prometheus.io/docs/prometheus/latest/migration/#le-and-quantile-label-values.
-// It specifically detects integers-only label matchers formatted as "integer" and "integer|integer|integer" (as they're the most likely to contain them).
-// Refer to Test_checkLabelMatchers for more details.
-func checkLabelMatchers(vs *VectorSelector) {
-Outer:
-	for _, lm := range vs.LabelMatchers {
-		if lm == nil {
-			continue
-		}
-		if lm.Name == model.QuantileLabel || (strings.HasSuffix(vs.Name, "_bucket") && lm.Name == model.BucketLabel) {
-			switch lm.Type {
-			case labels.MatchEqual, labels.MatchNotEqual:
-				if n, ok := isInteger(lm.Value); ok {
-					NarrowSelectors.WithLabelValues("parser").Inc()
-					Logger.Debug("selector set to explicitly match an integer, but values could be floats", "narrow_matcher_label", lm.Name, "integer", n, "matchers", vs.LabelMatchers)
-				}
-				break Outer
-			case labels.MatchRegexp, labels.MatchNotRegexp:
-				if lm.Value == "" {
-					break Outer
-				}
-				vals := strings.Split(lm.Value, "|")
-				for _, val := range vals {
-					if _, ok := isInteger(val); !ok {
-						break Outer
-					}
-				}
-
-				NarrowSelectors.WithLabelValues("parser").Inc()
-				Logger.Debug("selector set to explicitly match integers only, but values could be floats", "narrow_matcher_label", lm.Name, "matchers", vs.LabelMatchers)
-				break Outer
-			}
-		}
-	}
-}
 
 var parserPool = sync.Pool{
 	New: func() any {
@@ -989,8 +901,6 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 					p.addParseErrf(n.PositionRange(), "metric name must not be set twice: %q or %q", n.Name, m.Value)
 				}
 			}
-
-			checkLabelMatchers(n)
 
 			// Skip the check for non-empty matchers because an explicit
 			// metric name is a non-empty matcher.


### PR DESCRIPTION
No longer needed for OCP 5.0

One check as already dropped by mistake in https://github.com/openshift/prometheus/pull/305/files#diff-0accfa26d7e8bfecc27f0c77f5f7ecc5d2417cf16edfa7b8ca9d9ab5b822aff0

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
