### PR TITLE
[openshift-4.17] OCPBUGS-88631: remote: validate snappy decoded length before allocation in read endpoint

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -68,6 +68,14 @@ func DecodeReadRequest(r *http.Request) (*prompb.ReadRequest, error) {
 		return nil, err
 	}
 
+	decodedLen, err := snappy.DecodedLen(compressed)
+	if err != nil {
+		return nil, err
+	}
+	if decodedLen > decodeReadLimit {
+		return nil, fmt.Errorf("snappy: decoded length %d exceeds limit %d", decodedLen, decodeReadLimit)
+	}
+
 	reqBuf, err := snappy.Decode(nil, compressed)
 	if err != nil {
 		return nil, err

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -16,6 +16,7 @@ package remote
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"sync"
 	"testing"
 
@@ -514,6 +515,17 @@ func TestMetricTypeToMetricTypeProto(t *testing.T) {
 			require.Equal(t, tt.expected, m)
 		})
 	}
+}
+
+func TestDecodeReadRequestTooLarge(t *testing.T) {
+	// 5-byte snappy stream whose header claims 256 MiB decoded length,
+	// well above decodeReadLimit (32 MiB).
+	bomb := []byte{0x80, 0x80, 0x80, 0x80, 0x01}
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(bomb))
+	require.NoError(t, err)
+
+	_, err = DecodeReadRequest(req)
+	require.ErrorContains(t, err, "exceeds limit")
 }
 
 func TestDecodeWriteRequest(t *testing.T) {


### PR DESCRIPTION
Fix: remote: validate snappy decoded length before allocation in read endpoint
Fix for CVE-2026-42154

Jira: https://redhat.atlassian.net/browse/OCPBUGS-88631

Original Fix: https://github.com/prometheus/prometheus/pull/18584
Cherry-pick from 4.18 was not possible 