### PR TITLE
OCPBUGS-93655: remote/azuread: use Secret type for OAuth client_secret [release-4.15] 

### DIFF
--- a/storage/remote/azuread/azuread.go
+++ b/storage/remote/azuread/azuread.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/google/uuid"
+	config_util "github.com/prometheus/common/config"
 )
 
 const (
@@ -55,7 +56,7 @@ type OAuthConfig struct {
 	ClientID string `yaml:"client_id,omitempty"`
 
 	// ClientSecret is the clientSecret of the azure active directory application that is being used to authenticate.
-	ClientSecret string `yaml:"client_secret,omitempty"`
+	ClientSecret config_util.Secret `yaml:"client_secret,omitempty"`
 
 	// TenantID is the tenantId of the azure active directory application that is being used to authenticate.
 	TenantID string `yaml:"tenant_id,omitempty"`
@@ -238,7 +239,7 @@ func newManagedIdentityTokenCredential(clientOpts *azcore.ClientOptions, managed
 // newOAuthTokenCredential returns new OAuth token credential
 func newOAuthTokenCredential(clientOpts *azcore.ClientOptions, oAuthConfig *OAuthConfig) (azcore.TokenCredential, error) {
 	opts := &azidentity.ClientSecretCredentialOptions{ClientOptions: *clientOpts}
-	return azidentity.NewClientSecretCredential(oAuthConfig.TenantID, oAuthConfig.ClientID, oAuthConfig.ClientSecret, opts)
+	return azidentity.NewClientSecretCredential(oAuthConfig.TenantID, oAuthConfig.ClientID, string(oAuthConfig.ClientSecret), opts)
 }
 
 // newTokenProvider helps to fetch accessToken for different types of credential. This also takes care of


### PR DESCRIPTION
Fixes CVE-2026-42151 (GHSA-wg65-39gg-5wfj). OAuthConfig.ClientSecret was typed as a plain string, so it bypassed Prometheus's secret redaction and was exposed in plaintext via the
/api/v1/status/config API endpoint. Change it to config_util.Secret so it marshals to <secret> like other credentials.

